### PR TITLE
V1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,34 @@ Extends Auth driver's `.search` method by applying `.parse` to each result.
 
 ### .parse(obj: Object)
 
-Returns a valid auth user with some helper methods: `.is`, `.can` and `.allow`.
+Converts an Entity from the Auth Service into an Authorization instance with helper methods (see below).
+
+### .create(obj: Object)
+
+Creates a new entity within the Auth Service, then parses the new entity record into an Authorization instance.
+Note: You must provide the object in the Auth Service format (refer [entity schema](https://github.com/Prismatik/auth/blob/master/schemas/entity.md)), not a Authorization object.
+
+### .Authorization
+
+Provides direct access to the Authorization class, useful for testing permissions.
+
+```
+const Authorization = require('auth-driver-utils').Authorization;
+
+new Authorization(<id>, <role>, <permissions>)
+```
+
+Permissions must be in the Authorization format e.g.
+```
+permissions: {
+  <entity>: [<type>, <type>]
+  ...
+}
+```
+
+---
+
+### Authorization instance methods
 
 #### .is(id: UUID)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-driver-utils",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Useful methods to extend Auth driver.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import Authorization from './lib/authorization';
+import _Authorization from './lib/authorization';
 
 export default class Auth {
   constructor(client) {
@@ -32,7 +32,7 @@ export default class Auth {
 
     const entityType = obj.metadata && obj.metadata.type;
 
-    return new Authorization(obj.id, entityType, perms);
+    return new _Authorization(obj.id, entityType, perms);
   }
 
   errorify(err) {
@@ -40,3 +40,5 @@ export default class Auth {
     throw err;
   }
 }
+
+export const Authorization = _Authorization;

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,10 @@ export default class Auth {
     return this.client.get(id).then(this.parse).catch(this.errorify);
   }
 
+  create(data) {
+    return this.client.create(data).then(this.parse).catch(this.errorify);
+  }
+
   search(query) {
     return this.client.search(query)
       .then(entities => entities.map(this.parse))


### PR DESCRIPTION
This PR adds two small features.
1. Provides a .create method that parses the result into an Authorization.
2. Exposes the Authorization class so it can be used in tests.

Ideally the create method would accept either an Authorization instance or an Auth Entity record, but for now this will suffice. Or alternatively we could actually add a save method to the Authorization instance, that'd be super neato!

Once merged this needs publishing to NPM.
